### PR TITLE
fix: settings.gradle.kts에서의 buildSrc 참조 제거

### DIFF
--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -1,11 +1,6 @@
 object Plugins {
     private const val KOTLIN_VERSION = "1.9.25"
 
-    object FoojayResolver {
-        const val ID = "org.gradle.toolchains.foojay-resolver-convention"
-        const val VERSION = "0.8.0"
-    }
-
     object KotlinJVM {
         const val ID = "jvm"
         const val VERSION = KOTLIN_VERSION

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -1,5 +1,4 @@
 object Project {
-    const val ROOT_NAME = "xquare-infra"
     const val GROUP = "app.xquare"
     const val VERSION = "0.0.1-SNAPSHOT"
     const val DESCRIPTION = "xquare-infra-v3"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id(Plugins.FoojayResolver.ID) version Plugins.FoojayResolver.VERSION
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
-rootProject.name = Project.ROOT_NAME
+rootProject.name = "xquare-infra"


### PR DESCRIPTION
`settings.gradle.kts`는 `buildSrc`를 참조할 수 없다고 하네요

https://docs.gradle.org/current/userguide/upgrading_version_5.html#classes_from_buildsrc_are_no_longer_visible_to_settings_scripts