### PR TITLE
docs: add auth email swagger docs

### DIFF
--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/AuthController.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/AuthController.kt
@@ -39,7 +39,11 @@ class AuthController(
     private val sendEmailOtpUseCase: SendEmailOtpUseCase,
     private val verifyEmailOtpUseCase: VerifyEmailOtpUseCase,
 ) {
-    @Operation(summary = "이메일 OTP 발송")
+    @Operation(
+        tags = ["Email"],
+        summary = "회원가입 이메일 OTP 발송",
+        description = "회원가입에 사용할 이메일 주소로 6자리 OTP를 발송합니다.",
+    )
     @PostMapping("/email/send")
     fun sendEmailOtp(
         @RequestBody @Valid request: SendOtpRequestDto,
@@ -49,7 +53,11 @@ class AuthController(
         return APiWrappedResponseDto.success()
     }
 
-    @Operation(summary = "이메일 OTP 검증")
+    @Operation(
+        tags = ["Email"],
+        summary = "회원가입 이메일 OTP 검증",
+        description = "이메일로 받은 6자리 OTP를 검증하고 회원가입에 사용할 이메일 인증 토큰을 발급합니다.",
+    )
     @PostMapping("/email/verify")
     fun verifyEmailOtp(
         @RequestBody @Valid request: VerifyOtpRequestDto,

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/dtos/EmailVerifiedTokenResponseDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/dtos/EmailVerifiedTokenResponseDto.kt
@@ -1,7 +1,12 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.dtos
 
 import app.xquare.xquareinfra.infrastructure.web.dto.SuccessResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class EmailVerifiedTokenResponseDto(
+    @field:Schema(
+        description = "회원가입 요청에 함께 제출해야 하는 이메일 인증 토큰",
+        example = "7f4f7c50-4b53-4b63-a76d-625deea5b61f",
+    )
     val emailVerifiedToken: String,
 ) : SuccessResponseDto

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/dtos/SendOtpRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/dtos/SendOtpRequestDto.kt
@@ -1,8 +1,15 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 
 data class SendOtpRequestDto(
-    @field:Email @field:NotBlank val email: String,
+    @field:Schema(
+        description = "회원가입 이메일 인증 OTP를 받을 이메일 주소",
+        example = "student@xquare.app",
+    )
+    @field:Email
+    @field:NotBlank
+    val email: String,
 )

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/dtos/VerifyOtpRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/dtos/VerifyOtpRequestDto.kt
@@ -1,12 +1,25 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class VerifyOtpRequestDto(
-    @field:NotBlank @field:Email val email: String,
+    @field:Schema(
+        description = "회원가입 이메일 인증 OTP를 받은 이메일 주소",
+        example = "student@xquare.app",
+    )
+    @field:NotBlank
+    @field:Email
+    val email: String,
+    @field:Schema(
+        description = "이메일로 발송된 6자리 숫자 OTP",
+        example = "123456",
+    )
     @field:Pattern(regexp = "^\\d{6}$")
-    @field:Size(min = 6, max = 6) @field:NotBlank val otp: String,
+    @field:Size(min = 6, max = 6)
+    @field:NotBlank
+    val otp: String,
 )

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/AuthRecoveryController.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/AuthRecoveryController.kt
@@ -40,7 +40,11 @@ class AuthRecoveryController(
     private val verifyPasswordResetOtpUseCase: VerifyPasswordResetOtpUseCase,
     private val resetPasswordUseCase: ResetPasswordUseCase,
 ) {
-    @Operation(summary = "아이디 찾기 OTP 발송")
+    @Operation(
+        tags = ["Email"],
+        summary = "아이디 찾기 이메일 OTP 발송",
+        description = "학번, 이름, 이메일이 일치하는 사용자의 이메일로 아이디 찾기용 6자리 OTP를 발송합니다.",
+    )
     @PostMapping("/username/email/send")
     fun sendUsernameFindOtp(
         @RequestBody @Valid request: SendUsernameFindOtpRequestDto,
@@ -56,7 +60,11 @@ class AuthRecoveryController(
         return APiWrappedResponseDto.success()
     }
 
-    @Operation(summary = "아이디 찾기 OTP 검증")
+    @Operation(
+        tags = ["Email"],
+        summary = "아이디 찾기 이메일 OTP 검증",
+        description = "아이디 찾기용 이메일 OTP를 검증하고 해당 사용자의 아이디를 반환합니다.",
+    )
     @PostMapping("/username/email/verify")
     fun verifyUsernameFindOtp(
         @RequestBody @Valid request: VerifyUsernameFindOtpRequestDto,
@@ -74,7 +82,11 @@ class AuthRecoveryController(
         return UsernameResponseDto(result.username).toWrappedDto()
     }
 
-    @Operation(summary = "비밀번호 재설정 아이디 확인 및 OTP 발송")
+    @Operation(
+        tags = ["Email"],
+        summary = "비밀번호 재설정 이메일 OTP 발송",
+        description = "아이디, 학번, 이름, 이메일이 일치하는 사용자의 이메일로 비밀번호 재설정용 6자리 OTP를 발송합니다.",
+    )
     @PostMapping("/password/email/send")
     fun sendPasswordResetOtp(
         @RequestBody @Valid request: SendPasswordResetOtpRequestDto,
@@ -91,7 +103,11 @@ class AuthRecoveryController(
         return APiWrappedResponseDto.success()
     }
 
-    @Operation(summary = "비밀번호 재설정 OTP 검증")
+    @Operation(
+        tags = ["Email"],
+        summary = "비밀번호 재설정 이메일 OTP 검증",
+        description = "비밀번호 재설정용 이메일 OTP를 검증하고 비밀번호 변경에 사용할 재설정 토큰을 발급합니다.",
+    )
     @PostMapping("/password/email/verify")
     fun verifyPasswordResetOtp(
         @RequestBody @Valid request: VerifyPasswordResetOtpRequestDto,

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/PasswordResetTokenResponseDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/PasswordResetTokenResponseDto.kt
@@ -1,6 +1,7 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
 import app.xquare.xquareinfra.infrastructure.web.dto.SuccessResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * Returns the opaque, short-lived credential required to reset a password.
@@ -10,5 +11,9 @@ import app.xquare.xquareinfra.infrastructure.web.dto.SuccessResponseDto
  */
 data class PasswordResetTokenResponseDto(
     /** Opaque token supplied once to the password reset endpoint before it expires. */
+    @field:Schema(
+        description = "비밀번호 재설정 요청에 제출해야 하는 단기 재설정 토큰",
+        example = "7f4f7c50-4b53-4b63-a76d-625deea5b61f",
+    )
     val passwordResetToken: String,
 ) : SuccessResponseDto

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/ResetPasswordRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/ResetPasswordRequestDto.kt
@@ -1,12 +1,21 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class ResetPasswordRequestDto(
+    @field:Schema(
+        description = "비밀번호 재설정 OTP 검증 후 발급받은 재설정 토큰",
+        example = "7f4f7c50-4b53-4b63-a76d-625deea5b61f",
+    )
     @field:NotBlank
     val passwordResetToken: String,
+    @field:Schema(
+        description = "새 비밀번호. 8자 이상 20자 이하이며 특수문자를 1개 이상 포함해야 합니다.",
+        example = "newPassword!1",
+    )
     @field:Size(min = 8, max = 20)
     @field:Pattern(
         regexp = ".*[!@#\$%^&*(),.?\":{}|<>].*",

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/SendPasswordResetOtpRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/SendPasswordResetOtpRequestDto.kt
@@ -1,5 +1,6 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -7,18 +8,34 @@ import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class SendPasswordResetOtpRequestDto(
+    @field:Schema(
+        description = "비밀번호를 재설정할 사용자 아이디",
+        example = "xquare_user",
+    )
     @field:Size(min = 4, max = 15)
     @field:Pattern(
         regexp = "^[A-Za-z0-9_-]+$",
     )
     val username: String,
+    @field:Schema(
+        description = "사용자의 학번",
+        example = "1101",
+    )
     @field:Min(1000)
     @field:Max(3999)
     val studentNumber: Int,
+    @field:Schema(
+        description = "사용자의 이름",
+        example = "홍길동",
+    )
     @field:Pattern(
         regexp = "^[가-힣]+$",
     )
     val name: String,
+    @field:Schema(
+        description = "비밀번호 재설정 OTP를 받을 이메일 주소",
+        example = "student@xquare.app",
+    )
     @field:Email
     val email: String,
 )

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/SendUsernameFindOtpRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/SendUsernameFindOtpRequestDto.kt
@@ -1,5 +1,6 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -7,14 +8,26 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
 data class SendUsernameFindOtpRequestDto(
+    @field:Schema(
+        description = "사용자의 학번",
+        example = "1101",
+    )
     @field:Min(1000)
     @field:Max(3999)
     val studentNumber: Int,
+    @field:Schema(
+        description = "사용자의 이름. 한글 또는 영문 이름이며 공백과 하이픈을 포함할 수 있습니다.",
+        example = "홍길동",
+    )
     @field:Pattern(
         regexp = "^[A-Za-z가-힣]+(?:[ -][A-Za-z가-힣]+)*$",
     )
     @field:NotBlank
     val name: String,
+    @field:Schema(
+        description = "아이디 찾기 OTP를 받을 이메일 주소",
+        example = "student@xquare.app",
+    )
     @field:Email
     @field:NotBlank
     val email: String,

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/UsernameResponseDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/UsernameResponseDto.kt
@@ -1,7 +1,12 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
 import app.xquare.xquareinfra.infrastructure.web.dto.SuccessResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class UsernameResponseDto(
+    @field:Schema(
+        description = "아이디 찾기 OTP 검증에 성공한 사용자의 아이디",
+        example = "xquare_user",
+    )
     val username: String,
 ) : SuccessResponseDto

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/VerifyPasswordResetOtpRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/VerifyPasswordResetOtpRequestDto.kt
@@ -1,5 +1,6 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -8,20 +9,40 @@ import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class VerifyPasswordResetOtpRequestDto(
+    @field:Schema(
+        description = "비밀번호를 재설정할 사용자 아이디",
+        example = "xquare_user",
+    )
     @field:Size(min = 4, max = 15)
     @field:Pattern(
         regexp = "^[A-Za-z0-9_-]+$",
     )
     val username: String,
+    @field:Schema(
+        description = "사용자의 학번",
+        example = "1101",
+    )
     @field:Min(1000)
     @field:Max(3999)
     val studentNumber: Int,
+    @field:Schema(
+        description = "사용자의 이름",
+        example = "홍길동",
+    )
     @field:Pattern(
         regexp = "^[가-힣]+$",
     )
     val name: String,
+    @field:Schema(
+        description = "비밀번호 재설정 OTP를 받은 이메일 주소",
+        example = "student@xquare.app",
+    )
     @field:Email
     val email: String,
+    @field:Schema(
+        description = "이메일로 발송된 6자리 숫자 OTP",
+        example = "123456",
+    )
     @field:Pattern(regexp = "^[0-9]{6}$")
     @field:Size(min = 6, max = 6)
     @field:NotBlank

--- a/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/VerifyUsernameFindOtpRequestDto.kt
+++ b/src/main/kotlin/app/xquare/xquareinfra/adapters/inbound/web/auth/recovery/dtos/VerifyUsernameFindOtpRequestDto.kt
@@ -1,5 +1,6 @@
 package app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -8,17 +9,33 @@ import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class VerifyUsernameFindOtpRequestDto(
+    @field:Schema(
+        description = "사용자의 학번",
+        example = "1101",
+    )
     @field:Min(1000)
     @field:Max(3999)
     val studentNumber: Int,
+    @field:Schema(
+        description = "사용자의 이름. 한글 또는 영문 이름이며 공백과 하이픈을 포함할 수 있습니다.",
+        example = "홍길동",
+    )
     @field:Pattern(
         regexp = "^[A-Za-z가-힣]+(?:[ -][A-Za-z가-힣]+)*$",
     )
     @field:NotBlank
     val name: String,
+    @field:Schema(
+        description = "아이디 찾기 OTP를 받은 이메일 주소",
+        example = "student@xquare.app",
+    )
     @field:Email
     @field:NotBlank
     val email: String,
+    @field:Schema(
+        description = "이메일로 발송된 6자리 숫자 OTP",
+        example = "123456",
+    )
     @field:Pattern(regexp = "^\\d{6}$")
     @field:Size(min = 6, max = 6)
     @field:NotBlank

--- a/src/test/kotlin/app/xquare/xquareinfra/infrastructure/swagger/AuthEmailSwaggerDocumentationTest.kt
+++ b/src/test/kotlin/app/xquare/xquareinfra/infrastructure/swagger/AuthEmailSwaggerDocumentationTest.kt
@@ -1,0 +1,83 @@
+package app.xquare.xquareinfra.infrastructure.swagger
+
+import app.xquare.xquareinfra.adapters.inbound.web.auth.AuthController
+import app.xquare.xquareinfra.adapters.inbound.web.auth.dtos.EmailVerifiedTokenResponseDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.dtos.SendOtpRequestDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.dtos.VerifyOtpRequestDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.AuthRecoveryController
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.PasswordResetTokenResponseDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.ResetPasswordRequestDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.SendPasswordResetOtpRequestDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.SendUsernameFindOtpRequestDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.UsernameResponseDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.VerifyPasswordResetOtpRequestDto
+import app.xquare.xquareinfra.adapters.inbound.web.auth.recovery.dtos.VerifyUsernameFindOtpRequestDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaField
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AuthEmailSwaggerDocumentationTest {
+    @Test
+    fun `email endpoints are grouped under email swagger tag`() {
+        val emailEndpoints =
+            mapOf(
+                AuthController::class to listOf("sendEmailOtp", "verifyEmailOtp"),
+                AuthRecoveryController::class to
+                    listOf(
+                        "sendUsernameFindOtp",
+                        "verifyUsernameFindOtp",
+                        "sendPasswordResetOtp",
+                        "verifyPasswordResetOtp",
+                    ),
+            )
+
+        emailEndpoints.forEach { (controller, methodNames) ->
+            methodNames.forEach { methodName ->
+                val operation =
+                    controller.declaredMemberFunctions
+                        .single { it.name == methodName }
+                        .findAnnotation<Operation>()
+
+                assertNotNull(operation, "$methodName must declare @Operation")
+                assertTrue(
+                    operation.tags.contains("Email"),
+                    "$methodName must be exposed under the Email swagger tag",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `email request and response dto fields declare swagger schema descriptions`() {
+        val documentedDtos =
+            listOf(
+                SendOtpRequestDto::class,
+                VerifyOtpRequestDto::class,
+                EmailVerifiedTokenResponseDto::class,
+                SendUsernameFindOtpRequestDto::class,
+                VerifyUsernameFindOtpRequestDto::class,
+                UsernameResponseDto::class,
+                SendPasswordResetOtpRequestDto::class,
+                VerifyPasswordResetOtpRequestDto::class,
+                PasswordResetTokenResponseDto::class,
+                ResetPasswordRequestDto::class,
+            )
+
+        documentedDtos.forEach { dto ->
+            dto.memberProperties.forEach { property ->
+                val schema = property.javaField?.getAnnotation(Schema::class.java)
+                val fieldName = "${dto.simpleName}.${property.name}"
+
+                assertNotNull(schema, "$fieldName must declare @Schema")
+                assertTrue(schema.description.isNotBlank(), "$fieldName must describe the field")
+                assertTrue(schema.example.isNotBlank(), "$fieldName must provide an example")
+            }
+        }
+    }
+}


### PR DESCRIPTION
스웨거에 email관련 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 이메일 OTP 및 계정 복구 관련 API 문서가 더 상세해졌습니다.
  * 요청/응답 항목에 설명과 예시가 추가되어 스웨거에서 입력값과 반환값을 이해하기 쉬워졌습니다.

* **테스트**
  * 이메일 및 복구 관련 문서화 규칙을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->